### PR TITLE
Add MebloPlan Non-Commercial License file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,37 @@
+MebloPlan Non-Commercial License 1.0
+
+Copyright (c) 2024 MebloPlan contributors
+
+1. Definicje
+   a. "Utwór" oznacza kod źródłowy, zasoby oraz dokumentację projektu MebloPlan.
+   b. "Współautorzy" oznaczają osoby, które wniosły wkład twórczy do Utworu i których nazwiska są wskazane w historii repozytorium lub dokumentacji.
+   c. "Zastosowanie niekomercyjne" oznacza korzystanie z Utworu wyłącznie w celach edukacyjnych, badawczych, hobbystycznych lub osobistych, bez uzyskiwania z tego tytułu bezpośrednich ani pośrednich przychodów pieniężnych.
+
+2. Udzielenie licencji
+   Współautorzy udzielają niewyłącznej, nieodpłatnej i nieprzenoszalnej licencji na korzystanie z Utworu na warunkach określonych w niniejszym dokumencie.
+
+3. Dozwolone pola eksploatacji
+   a. Użytkownik może pobierać, kopiować, instalować i uruchamiać Utwór.
+   b. Użytkownik może modyfikować Utwór oraz tworzyć utwory zależne, pod warunkiem zachowania niniejszej licencji w oryginalnej postaci i dołączania jej do wszelkich kopii oraz utworów zależnych.
+   c. Użytkownik może publicznie prezentować Utwór lub utwory zależne w celach niekomercyjnych, z zastrzeżeniem spełnienia warunków określonych w sekcji 5.
+
+4. Ograniczenia
+   a. Jakiekolwiek wykorzystanie Utworu lub utworów zależnych w celach komercyjnych wymaga uprzedniej, wyraźnej i pisemnej zgody wszystkich Współautorów.
+   b. Zabronione jest usuwanie, modyfikowanie lub ukrywanie informacji o prawach autorskich, autorach lub licencji w Utworze.
+   c. Licencja nie upoważnia do re-licencjonowania Utworu na warunkach innych niż niniejsza licencja bez zgody Współautorów.
+
+5. Obowiązki informacyjne
+   a. Użytkownik ma obowiązek zachować i eksponować w sposób czytelny wzmiankę o autorach oraz o niniejszej licencji we wszystkich kopiach Utworu oraz utworach zależnych.
+   b. Użytkownik zobowiązany jest do oznaczenia każdej modyfikacji wraz z datą jej dokonania.
+   c. Na żądanie Współautorów użytkownik dostarczy opis zakresu i sposobu wykorzystania Utworu.
+
+6. Ograniczenie odpowiedzialności
+   Utwór jest dostarczany "tak jak jest", bez jakichkolwiek gwarancji, w tym gwarancji przydatności do określonego celu. W maksymalnym zakresie dozwolonym przez prawo Współautorzy nie ponoszą odpowiedzialności za szkody powstałe w związku z korzystaniem z Utworu.
+
+7. Rozwiązanie licencji
+   Naruszenie któregokolwiek z warunków niniejszej licencji skutkuje jej automatycznym rozwiązaniem ze skutkiem natychmiastowym. W przypadku rozwiązania licencji użytkownik zobowiązany jest do zaprzestania korzystania z Utworu oraz usunięcia wszystkich jego kopii.
+
+8. Postanowienia końcowe
+   a. Niniejsza licencja podlega prawu Rzeczypospolitej Polskiej.
+   b. Ewentualne zmiany niniejszej licencji wymagają zgody wszystkich Współautorów i obowiązują wyłącznie w stosunku do wersji Utworu opublikowanych po dacie takiej zmiany.
+

--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ Projekt zawiera podstawowe moduły logiki aplikacji bez interfejsu graficznego.
 
 ## Licencja
 
-Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów.
+Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów. Pełna treść licencji znajduje się w pliku [LICENSE](LICENSE).
 
 Wszyscy współautorzy wyrazili zgodę na zmianę licencji. Zmiana obowiązuje jedynie dla wersji opublikowanych po 2025-08-30; wcześniejsze wydania pozostają na licencji MIT.


### PR DESCRIPTION
## Summary
- add the full text of the MebloPlan Non-Commercial License 1.0 to a new LICENSE file
- update the README to point readers to the dedicated license file

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68c85f6d76108322b3ecd360a194c5ad