### PR TITLE
Update README to reflect Planer repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-[![CI](https://github.com/iniemamocny/MebloPlan/actions/workflows/ci.yml/badge.svg)](https://github.com/iniemamocny/MebloPlan/actions/workflows/ci.yml)
-[![Pages](https://github.com/iniemamocny/MebloPlan/actions/workflows/pages.yml/badge.svg)](https://github.com/iniemamocny/MebloPlan/actions/workflows/pages.yml)
+[![CI](https://github.com/iniemamocny/Planer/actions/workflows/ci.yml/badge.svg)](https://github.com/iniemamocny/Planer/actions/workflows/ci.yml)
+[![Pages](https://github.com/iniemamocny/Planer/actions/workflows/pages.yml/badge.svg)](https://github.com/iniemamocny/Planer/actions/workflows/pages.yml)
 [![License: NonCommercial](https://img.shields.io/badge/License-NonCommercial-blue.svg)](LICENSE)
 
+# Planer
 
-# MebloPlan 
-
-Projekt zawiera podstawowe moduły logiki aplikacji bez interfejsu graficznego.
+Projekt zawiera podstawowe moduły logiki aplikacji Planer bez interfejsu graficznego.
 
 ## Licencja
 
-Projekt jest udostępniany na licencji **MebloPlan Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów. Pełna treść licencji znajduje się w pliku [LICENSE](LICENSE).
+Projekt jest udostępniany na licencji **Planer Non-Commercial License 1.0**. Użytkowanie, kopiowanie oraz modyfikacja kodu są dozwolone wyłącznie w celach niekomercyjnych i przy zachowaniu informacji o autorach. Wykorzystanie komercyjne wymaga wcześniejszej zgody wszystkich współautorów. Pełna treść licencji znajduje się w pliku [LICENSE](LICENSE).
 
 Wszyscy współautorzy wyrazili zgodę na zmianę licencji. Zmiana obowiązuje jedynie dla wersji opublikowanych po 2025-08-30; wcześniejsze wydania pozostają na licencji MIT.


### PR DESCRIPTION
## Summary
- rename the README heading and description to use the Planer project name
- point the status badges at the Planer GitHub repository URLs

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c8601fa9788322b7433557c4cc72e8