### PR TITLE
Add Node types support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@eslint/js": "^9.35.0",
         "@types/jest": "^30.0.0",
+        "@types/node": "^24.4.0",
         "eslint": "^9.35.0",
         "eslint-plugin-react": "^7.37.5",
         "globals": "^16.4.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@eslint/js": "^9.35.0",
     "@types/jest": "^30.0.0",
+    "@types/node": "^24.4.0",
     "eslint": "^9.35.0",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^16.4.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     // See also https://aka.ms/tsconfig/module
     "module": "nodenext",
     "target": "esnext",
-    "types": [],
+    "types": ["node"],
     // For nodejs:
     // "lib": ["esnext"],
     // "types": ["node"],


### PR DESCRIPTION
## Summary
- add the @types/node package as a development dependency
- enable Node.js type definitions via tsconfig

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c85bcca7908322ad155a1e881115f4