### PR TITLE
Add tests for health module

### DIFF
--- a/core/models/health.js
+++ b/core/models/health.js
@@ -1,0 +1,1 @@
+export * from './health.ts';

--- a/core/modules/__tests__/health.test.ts
+++ b/core/modules/__tests__/health.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+describe('health module', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns default API health details', async () => {
+    const { getApiHealth } = await import('../health.ts');
+
+    const health = getApiHealth();
+
+    expect(health).toMatchObject({
+      service: 'api',
+      message: 'Planer API is running smoothly',
+      level: 'operational',
+    });
+    expect(typeof health.checkedAt).toBe('string');
+    expect(new Date(health.checkedAt).toString()).not.toBe('Invalid Date');
+  });
+
+  it('reports uptime that increases over time', async () => {
+    jest.useFakeTimers();
+
+    const initial = new Date('2024-01-01T00:00:00.000Z');
+    jest.setSystemTime(initial);
+
+    const { getUptimeSeconds } = await import('../health.ts');
+
+    expect(getUptimeSeconds()).toBe(0);
+
+    jest.advanceTimersByTime(2000);
+    const uptimeAfterTwoSeconds = getUptimeSeconds();
+    expect(uptimeAfterTwoSeconds).toBe(2);
+
+    jest.advanceTimersByTime(1500);
+    expect(getUptimeSeconds()).toBeGreaterThan(uptimeAfterTwoSeconds);
+  });
+
+  it('returns a summary with health details and uptime', async () => {
+    const { getHealthSummary } = await import('../health.ts');
+
+    const summary = getHealthSummary();
+
+    expect(summary).toEqual({
+      health: expect.objectContaining({
+        service: 'api',
+        message: 'Planer API is running smoothly',
+        level: 'operational',
+        checkedAt: expect.any(String),
+      }),
+      uptimeSeconds: expect.any(Number),
+    });
+    expect(summary.uptimeSeconds).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "jest",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "start": "ts-node api/server.ts",
     "dev": "vite --open",
     "build": "tsc",


### PR DESCRIPTION
## Summary
- add Jest tests covering health module defaults, uptime behaviour, and summary output
- adjust the test script to execute Jest with Node's VM modules support for ESM TypeScript
- provide a JavaScript re-export for the health model so runtime imports resolve during tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c87c6837348322a02fcc6c1a01f35a