### PR TITLE
feat: create planner home page with tab navigation

### DIFF
--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -1,0 +1,323 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  color: #0f172a;
+  background-color: #f4f6fb;
+  color-scheme: light;
+  --primary: #4356ff;
+  --primary-soft: rgba(67, 86, 255, 0.12);
+  --border: #d9e1f2;
+  --surface: #ffffff;
+  --surface-muted: #f8f9fe;
+  --text-muted: #5a6677;
+  --shadow: 0 14px 40px -28px rgba(67, 86, 255, 0.4);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--surface-muted);
+}
+
+body,
+button {
+  font-family: inherit;
+}
+
+a {
+  color: inherit;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #f8f9fe 0%, #f4f6fb 50%, #eef2fb 100%);
+}
+
+.app-nav {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 2.5rem;
+  background: rgba(255, 255, 255, 0.88);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid var(--border);
+}
+
+.app-brand {
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  text-decoration: none;
+  color: #1c2654;
+}
+
+.app-nav-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.app-nav-note {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  background: var(--surface-muted);
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+}
+
+.app-content {
+  flex: 1;
+  padding: 3.5rem 1.5rem 4rem;
+}
+
+.page {
+  width: min(960px, 100%);
+  margin: 0 auto;
+}
+
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2.5rem;
+}
+
+.hero-eyebrow {
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--primary);
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2rem, 4vw, 3.1rem);
+  letter-spacing: -0.03em;
+}
+
+.hero-lead {
+  margin: 0;
+  font-size: 1.1rem;
+  color: var(--text-muted);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.primary-action,
+.secondary-action {
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 0.75rem 1.2rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.primary-action {
+  border: none;
+  cursor: pointer;
+  color: #fff;
+  background: linear-gradient(135deg, #445fff 0%, #6a8bff 100%);
+  box-shadow: var(--shadow);
+}
+
+.primary-action:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 45px -26px rgba(67, 86, 255, 0.5);
+}
+
+.secondary-action {
+  border: none;
+  cursor: pointer;
+  color: var(--primary);
+  background: var(--primary-soft);
+}
+
+.secondary-action:hover {
+  background: rgba(67, 86, 255, 0.18);
+  transform: translateY(-1px);
+}
+
+.tab-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.75rem;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  box-shadow: 0 20px 50px -35px rgba(15, 23, 42, 0.45);
+  margin-bottom: 1.75rem;
+}
+
+.tab-button {
+  position: relative;
+  border: none;
+  background: transparent;
+  padding: 0.65rem 1.1rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-button:hover {
+  color: var(--primary);
+  background: rgba(67, 86, 255, 0.08);
+}
+
+.tab-button.is-active {
+  color: #1b2652;
+  background: linear-gradient(135deg, rgba(67, 86, 255, 0.14) 0%, rgba(106, 139, 255, 0.12) 100%);
+  box-shadow: inset 0 0 0 1px rgba(67, 86, 255, 0.18);
+}
+
+.tab-content {
+  background: var(--surface);
+  border-radius: 1.25rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 60px -36px rgba(15, 23, 42, 0.5);
+  padding: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.tab-content h2 {
+  margin: 0;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  letter-spacing: -0.01em;
+}
+
+.tab-lead {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.tab-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.tab-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.65rem;
+  font-size: 0.95rem;
+  color: #1f2937;
+}
+
+.tab-list li::before {
+  content: '•';
+  color: var(--primary);
+  font-size: 1.2rem;
+  line-height: 1;
+  margin-top: 0.1rem;
+}
+
+.tab-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 1.1rem 1.25rem;
+  border-radius: 0.9rem;
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  line-height: 1.45;
+}
+
+.info-card {
+  background: var(--surface);
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  box-shadow: 0 24px 60px -38px rgba(15, 23, 42, 0.45);
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.info-card h1 {
+  margin: 0;
+}
+
+.info-card p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.return-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 600;
+  color: var(--primary);
+  text-decoration: none;
+}
+
+.return-link:hover {
+  text-decoration: underline;
+}
+
+.app-footer {
+  margin-top: auto;
+  padding: 2rem 1rem 2.5rem;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 720px) {
+  .app-nav {
+    padding: 0.9rem 1.5rem;
+  }
+
+  .app-content {
+    padding: 2.5rem 1rem 3rem;
+  }
+
+  .tab-content,
+  .info-card {
+    padding: 1.5rem;
+  }
+}
+
+@media (max-width: 520px) {
+  .app-nav {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .tab-bar {
+    padding: 0.5rem;
+  }
+
+  .tab-button {
+    flex: 1 1 100%;
+    text-align: center;
+  }
+}

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,29 +1,178 @@
+import { useState } from 'react';
 import { Link, Route, Routes } from 'react-router-dom';
+import './App.css';
 
-const Home = () => (
-  <section className="page">
-    <h1>Planer</h1>
-    <p>Witaj w aplikacji Planer. Tutaj pojawi się Twoja nowa przestrzeń do planowania.</p>
-  </section>
-);
+type TabId = 'szafki' | 'pomieszczenie' | 'koszty' | 'formatki';
+
+type TabSection = {
+  id: TabId;
+  label: string;
+  title: string;
+  lead: string;
+  highlights: string[];
+  summary: string;
+};
+
+const TAB_SECTIONS: TabSection[] = [
+  {
+    id: 'szafki',
+    label: 'Szafki',
+    title: 'Moduły szafek pod pełną kontrolą',
+    lead: 'Zaplanuj układ korpusów i frontów dopasowany do każdego wnętrza.',
+    highlights: [
+      'Korzystaj z biblioteki modułów dolnych, górnych i wysokich z gotowymi rozstawami.',
+      'Definiuj kolory, okucia oraz fronty z natychmiastowym podglądem zmian.',
+      'Pilnuj ergonomii dzięki inteligentnym odstępom i blokadom kolizji.',
+    ],
+    summary:
+      'Planer automatycznie aktualizuje wymiary i sugeruje optymalne ułożenie szafek, aby Twój projekt był gotowy do produkcji.',
+  },
+  {
+    id: 'pomieszczenie',
+    label: 'Pomieszczenie',
+    title: 'Modelowanie pomieszczenia krok po kroku',
+    lead: 'Zacznij od dokładnych wymiarów i elementów wyposażenia, aby zbudować wiarygodny model.',
+    highlights: [
+      'Wprowadź wymiary ścian, wnęk, okien i instalacji bezpośrednio na siatce pomiarowej.',
+      'Zobacz natychmiastowy podgląd 2D oraz lekką wizualizację 3D.',
+      'Zapisuj warianty układu i porównuj je z klientem w jednym miejscu.',
+    ],
+    summary:
+      'Każda zmiana w pomieszczeniu automatycznie aktualizuje przestrzeń roboczą dla szafek i pozostałych etapów projektu.',
+  },
+  {
+    id: 'koszty',
+    label: 'Koszty',
+    title: 'Kontrola kosztów i materiałów',
+    lead: 'Budżet projektu aktualizuje się wraz z każdym modułem i dodatkiem.',
+    highlights: [
+      'Łącz cenniki materiałów, okuć i robocizny w jednym kalkulatorze.',
+      'Porównuj warianty cenowe oraz twórz wyceny gotowe do wysłania klientowi.',
+      'Dodawaj własne marże i automatycznie aktualizuj podsumowania VAT.',
+    ],
+    summary:
+      'Moduł kosztów pokazuje przejrzyste rozbicie pozycji i pomaga utrzymać rentowność każdego projektu.',
+  },
+  {
+    id: 'formatki',
+    label: 'Formatki',
+    title: 'Listy formatek i produkcja',
+    lead: 'Generuj komplet dokumentów do cięcia bez żmudnego przepisywania wymiarów.',
+    highlights: [
+      'Eksportuj listy elementów do formatu CSV, PDF lub bezpośrednio do programu rozkroju.',
+      'Oznaczaj krawędzie, okleiny i wiercenia, aby uniknąć pomyłek na produkcji.',
+      'Śledź status przygotowania formatek i weryfikuj stany magazynowe.',
+    ],
+    summary:
+      'Automatyczne listy formatek zamykają proces projektowy, dzięki czemu możesz od razu przekazać projekt do produkcji.',
+  },
+];
+
+const Home = () => {
+  const [activeTab, setActiveTab] = useState<TabId>(TAB_SECTIONS[0]?.id ?? 'szafki');
+  const activeSection =
+    TAB_SECTIONS.find((section) => section.id === activeTab) ?? TAB_SECTIONS[0];
+
+  return (
+    <section className="page home">
+      <header className="hero">
+        <span className="hero-eyebrow">Planowanie zabudów meblowych</span>
+        <h1>Stwórz kompletny projekt zabudowy od pomiaru po listę formatek</h1>
+        <p className="hero-lead">
+          Planer prowadzi przez każdy etap pracy nad zabudową — od stworzenia pomieszczenia,
+          przez konfigurację szafek, aż po szczegółową wycenę i dokumentację dla produkcji.
+        </p>
+        <div className="hero-actions">
+          <button
+            type="button"
+            className="primary-action"
+            onClick={() => setActiveTab('szafki')}
+          >
+            Zacznij od szafek
+          </button>
+          <button
+            type="button"
+            className="secondary-action"
+            onClick={() => setActiveTab('koszty')}
+          >
+            Zobacz moduł kosztów
+          </button>
+        </div>
+      </header>
+
+      <div className="tab-bar" role="tablist" aria-label="Sekcje planera">
+        {TAB_SECTIONS.map((section) => {
+          const isActive = activeSection.id === section.id;
+          return (
+            <button
+              key={section.id}
+              type="button"
+              id={`tab-${section.id}`}
+              className={`tab-button${isActive ? ' is-active' : ''}`}
+              role="tab"
+              aria-selected={isActive}
+              aria-controls={`panel-${section.id}`}
+              tabIndex={isActive ? 0 : -1}
+              onClick={() => setActiveTab(section.id)}
+            >
+              {section.label}
+            </button>
+          );
+        })}
+      </div>
+
+      <article
+        className="tab-content"
+        id={`panel-${activeSection.id}`}
+        role="tabpanel"
+        aria-labelledby={`tab-${activeSection.id}`}
+      >
+        <div>
+          <h2>{activeSection.title}</h2>
+          <p className="tab-lead">{activeSection.lead}</p>
+        </div>
+        <ul className="tab-list">
+          {activeSection.highlights.map((highlight) => (
+            <li key={highlight}>{highlight}</li>
+          ))}
+        </ul>
+        <div className="tab-summary">{activeSection.summary}</div>
+      </article>
+    </section>
+  );
+};
 
 const NotFound = () => (
   <section className="page">
-    <h1>Nie znaleziono</h1>
-    <p>Ta trasa jest jeszcze w przygotowaniu.</p>
-    <Link to="/">Wróć do strony głównej</Link>
+    <article className="info-card">
+      <h1>Nie znaleziono strony</h1>
+      <p>Ta trasa jest jeszcze w przygotowaniu.</p>
+      <Link to="/" className="return-link">
+        Wróć do strony głównej
+      </Link>
+    </article>
   </section>
 );
 
 const App = () => (
   <div className="app-shell">
     <nav className="app-nav">
-      <Link to="/">Strona główna</Link>
+      <Link to="/" className="app-brand">
+        Planer
+      </Link>
+      <div className="app-nav-actions">
+        <span className="app-nav-note">Wersja demonstracyjna</span>
+      </div>
     </nav>
-    <Routes>
-      <Route path="/" element={<Home />} />
-      <Route path="*" element={<NotFound />} />
-    </Routes>
+    <main className="app-content">
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="*" element={<NotFound />} />
+      </Routes>
+    </main>
+    <footer className="app-footer">
+      © {new Date().getFullYear()} Planer. Przestrzeń do projektowania zabudów meblowych.
+    </footer>
   </div>
 );
 


### PR DESCRIPTION
## Summary
- build a new landing page with hero content and interactive tabs for kluczowe moduły
- refresh the application shell with a sticky navigation bar, demo note, and footer
- add dedicated styles for the tabbed layout plus responsive adjustments

## Testing
- npm test
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68c879e4aad88322a2a65778b73ebbd2