### PR TITLE
Add Express 404 and error handling middleware

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -1,4 +1,4 @@
-import express, { type Request, type Response } from 'express';
+import express, { type NextFunction, type Request, type Response } from 'express';
 import { getHealthSummary } from '../core/modules/health.js';
 
 const app = express();
@@ -26,6 +26,17 @@ app.get('/', (_req: Request, res: Response) => {
 app.get('/health', (_req: Request, res: Response) => {
   res.json(getHealthSummary());
 });
+
+app.use((_req: Request, res: Response) => {
+  res.status(404).send('Not Found');
+});
+
+app.use(
+  (err: unknown, _req: Request, res: Response, _next: NextFunction) => {
+    console.error('Unhandled error:', err);
+    res.status(500).json({ error: 'Internal Server Error' });
+  },
+);
 
 app.listen(port, () => {
   console.log(`Server listening at http://localhost:${port}`);


### PR DESCRIPTION
## Summary
- add an Express middleware that returns a 404 response for unknown routes
- add a global error handler that logs errors and returns a 500 JSON response

## Testing
- npm run build *(fails: TS5097 - allowImportingTsExtensions is not enabled for test imports)*
- npm test *(fails: Jest cannot resolve '../health.ts' from compiled test files)*
- curl -i http://localhost:3000/non-existent
- curl -i http://localhost:3000/test-error

------
https://chatgpt.com/codex/tasks/task_e_68c88fd45c948322af624458284f91fb