### PR TITLE
Refresh docs build for GitHub Pages

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planer Frontend</title>
     <script type="module" crossorigin src="./assets/index-BaA63BK5.js"></script>

--- a/docs/vite.svg
+++ b/docs/vite.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#646cff" />
+      <stop offset="100%" stop-color="#61dafb" />
+    </linearGradient>
+  </defs>
+  <rect x="64" y="64" width="384" height="384" rx="96" fill="url(#gradient)" />
+  <path
+    d="M256 152c-12 0-22 9-24 21l-32 192a24 24 0 0 0 23 27h96a24 24 0 0 0 23-27l-32-192c-2-12-12-21-24-21z"
+    fill="#ffffff"
+  />
+</svg>

--- a/ui/index.html
+++ b/ui/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Planer Frontend</title>
   </head>

--- a/ui/public/vite.svg
+++ b/ui/public/vite.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" aria-hidden="true">
+  <defs>
+    <linearGradient id="gradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#646cff" />
+      <stop offset="100%" stop-color="#61dafb" />
+    </linearGradient>
+  </defs>
+  <rect x="64" y="64" width="384" height="384" rx="96" fill="url(#gradient)" />
+  <path
+    d="M256 152c-12 0-22 9-24 21l-32 192a24 24 0 0 0 23 27h96a24 24 0 0 0 23-27l-32-192c-2-12-12-21-24-21z"
+    fill="#ffffff"
+  />
+</svg>


### PR DESCRIPTION
## Summary
- update the Vite HTML template to load the favicon from a relative path suitable for GitHub Pages
- add a bundled svg icon to the frontend public assets and generated docs output
- rebuild the docs/ directory from the latest frontend build for Pages hosting

## Testing
- npm run build:frontend

------
https://chatgpt.com/codex/tasks/task_e_68c893f1ccd88322ae7d9b81589f5f72